### PR TITLE
fix(callback): promises with superagent

### DIFF
--- a/lib/superapi/api.js
+++ b/lib/superapi/api.js
@@ -39,8 +39,13 @@ var serviceHandler = function(service) {
 
     req.on('error', resolver.reject);
 
-    req.end(callback ? callback : function(res) {
-      resolver[!res.error ? "resolve" : "reject"](res);
+    req.end(callback ? callback : function(err, res) {
+      if(err) {
+        resolver.reject(err);
+      }
+      else {
+        resolver.resolve(res);
+      }
     });
 
     if (timeout) {


### PR DESCRIPTION
When no callback is given in a request object, the default
callback signature is wrong which breaks the promise chain
when using superagent.